### PR TITLE
Fluid images for liquid/responsive layouts

### DIFF
--- a/media/css/base.css
+++ b/media/css/base.css
@@ -16,6 +16,8 @@ html[xmlns] .clearfix { display: block; }
     margin-right: 1em; border-radius: 8px; }
 .navbar-fixed-top form { margin: 0; padding: 0.5em 0 0.5em 0; display: inline }
 
+img { max-width: 100%; }
+
 /* For some reason the bootstrap navbar isn't pushing content down without this */
 .navbar-fixed-top { position: static; }
 


### PR DESCRIPTION
Setting max-width:100% for inline images prevents them from overflowing their containers when the width changes.

This should fix https://github.com/mozilla/badges.mozilla.org/issues/14
