### PR TITLE
Nix &nbsp; in "Mozilla&nbsp;Badge&nbsp;Backpack"

### DIFF
--- a/badgus/base/templates/badger/award_detail.html
+++ b/badgus/base/templates/badger/award_detail.html
@@ -65,7 +65,7 @@
                 {% if award.user == request.user %}
                     <li><form class="obi_issuer">
                         <button class="btn issue" style="width: 18em"><img class="obi_icons" width="32" style="margin: 0 0em 0em 0; float: left" src="{{ static('img/openbadges-breakout.png') }}" />
-                            <strong>{{_("Add this badge to your Mozilla&nbsp;Badge&nbsp;Backpack")}}</strong></button>
+                            <strong>{{_('Add this badge to your Mozilla Badge Backpack')}}</strong></button>
                     </form></li>
                 {% endif %}
 


### PR DESCRIPTION
Fixes #50

I think this was there to make sure that "Mozilla Badge Backpack" wasn't broken up, but it gets escaped so it looks a little funny. I'm taking it out for now.

Quick r?
