### PR TITLE
Attempt to fix errors involving gettext, unicode, and string formatting in templates

### DIFF
--- a/badgus/base/templates/badger/award_detail.html
+++ b/badgus/base/templates/badger/award_detail.html
@@ -15,7 +15,7 @@
 
 {% block extrahead %}
     <link rel="alternate" type="application/json"
-        title="{{ _('{title} (JSON)') | f(title=award) }}"
+        title="{{ _('{title} (JSON)') | fe(title=award) }}"
         href="{{ request.build_absolute_uri(url('badger.award_detail_json', badge.slug, award.pk)) }}" />
 
      <meta property="og:type" content="article"> 
@@ -36,9 +36,9 @@
 <header class="page-header">
     <h2 class="badge-title">
         {% if award.user == request.user %}
-            {{ _("Your Awarded Badge: {badge_title}") | f(badge_title=badge.title) }}
+            {{ _("Your Awarded Badge: {badge_title}") | fe(badge_title=badge.title) }}
         {% else %}
-            {{ _("Awarded Badge: {badge_title}") | f(badge_title=badge.title) }}
+            {{ _("Awarded Badge: {badge_title}") | fe(badge_title=badge.title) }}
         {% endif %}
     </h2>
 </header>

--- a/badgus/base/templates/badger/awards_by_badge.html
+++ b/badgus/base/templates/badger/awards_by_badge.html
@@ -13,7 +13,7 @@
 <section class="row-fluid">
     <section>
         <header class="page-header">
-            <h2>{{ _("Badge detail for {title}") | f(title=badge.title) }}</h2>
+            <h2>{{ _("Badge detail for {title}") | fe(title=badge.title) }}</h2>
         </header>
         {% include "badger/includes/badge_full.html" %}
     </section>

--- a/badgus/base/templates/badger/awards_by_user.html
+++ b/badgus/base/templates/badger/awards_by_user.html
@@ -11,7 +11,7 @@
 {% block content %}
 <section class="awards_list">
     <header class="page-header">
-        <h2>{{ _("Awards for {user}") | f(user=user) }}</h2>
+        <h2>{{ _("Awards for {user}") | fe(user=user) }}</h2>
     </header>
     {% include "badger/includes/awards_as_badges_list.html" %}
 </section>

--- a/badgus/base/templates/badger/awards_list.html
+++ b/badgus/base/templates/badger/awards_list.html
@@ -13,7 +13,7 @@
 <section class="awards_list" class="item_flow">
     <header class="page-header">
         {% if badge %}
-            <h2>{{ _("Awarded badges for {badge}") | f(badge=badge) }}</h2>
+            <h2>{{ _("Awarded badges for {badge}") | fe(badge=badge) }}</h2>
         {% else: %}
             <h2>{{ _("Awarded badges") }}</h2>
         {% endif %}

--- a/badgus/base/templates/badger/badge_award.html
+++ b/badgus/base/templates/badger/badge_award.html
@@ -8,7 +8,7 @@
 
     <section class="span4" id="detail">
         <header class="page-header">
-            <h2>{{ _("Badge: {badge_title}") | f(badge_title=badge.title) }}</h2>
+            <h2>{{ _("Badge: {badge_title}") | fe(badge_title=badge.title) }}</h2>
         </header>
         {% include "badger/includes/badge_full.html" %}
     </section>

--- a/badgus/base/templates/badger/badge_delete.html
+++ b/badgus/base/templates/badger/badge_delete.html
@@ -8,7 +8,7 @@
 
     <section class="span4" id="detail">
         <header class="page-header">
-            <h2>{{ _("Badge: {badge_title}") | f(badge_title=badge.title) }}</h2>
+            <h2>{{ _("Badge: {badge_title}") | fe(badge_title=badge.title) }}</h2>
         </header>
         {% include "badger/includes/badge_full.html" %}
     </section>

--- a/badgus/base/templates/badger/badge_detail.html
+++ b/badgus/base/templates/badger/badge_detail.html
@@ -15,7 +15,7 @@
         title="{{ _('Recent awards') }}"
         href="{{ url('badger.feeds.awards_by_badge', format='atom', slug=badge.slug) }}" />
     <link rel="alternate" type="application/json"
-        title="{{ _('{title} (JSON)') | f(title=badge) }}"
+        title="{{ _('{title} (JSON)') | fe(title=badge) }}"
         href="{{ url('badger.detail_json', slug=badge.slug) }}" />
 
      <meta property="og:type" content="article"> 
@@ -37,7 +37,7 @@
 
     <section class="span4" id="detail">
         <header class="page-header">
-            <h2 class="badge-title">{{ _("Badge: {badge_title}") | f(badge_title=badge.title) }}</h2>
+            <h2 class="badge-title">{{ _("Badge: {badge_title}") | fe(badge_title=badge.title) }}</h2>
         </header>
         {% include "badger/includes/badge_full.html" %}
         {% if not award %}
@@ -134,7 +134,7 @@
                     <select name="amount">
                         <option value="1">1 reusable claim code</option>
                         {% for x in (6, 12, 24, 48, 72, 96) %}
-                            <option value="{{ x }}">{{ _('{num} single-use claim codes') | f(num=x) }}</option>
+                            <option value="{{ x }}">{{ _('{num} single-use claim codes') | fe(num=x) }}</option>
                         {% endfor %}
                     </select>
                     <input type="submit" class="btn btn-large btn-primary submit" value="{{ _("Generate") }}">
@@ -153,7 +153,7 @@
                                 <a class="btn" target="_blank" href="{{ url('badger.claims_list', badge.slug, item.claim_group) }}">
                                     <strong class="modified">{{ item.modified }}</strong>
                                     &#8212;
-                                    <span class="count">{{ _('{count} single-use codes') | f(count=item.count) }}</span>
+                                    <span class="count">{{ _('{count} single-use codes') | fe(count=item.count) }}</span>
                                 </a>
                                 &#8212;
                                 <a class="btn btn-success" 

--- a/badgus/base/templates/badger/badge_edit.html
+++ b/badgus/base/templates/badger/badge_edit.html
@@ -6,7 +6,7 @@
 
 <section>
     <header class="page-header">
-        <h2>{{ _("Edit badge: {title}") | f(title=badge.title) }}</h2>
+        <h2>{{ _("Edit badge: {title}") | fe(title=badge.title) }}</h2>
     </header>
 
     <form id="edit_badge" class="form-horizontal" 

--- a/badgus/base/templates/badger/badge_nominate_for.html
+++ b/badgus/base/templates/badger/badge_nominate_for.html
@@ -8,7 +8,7 @@
 
     <section class="span4" id="detail">
         <header class="page-header">
-            <h2>{{ _("Badge: {badge_title}") | f(badge_title=badge.title) }}</h2>
+            <h2>{{ _("Badge: {badge_title}") | fe(badge_title=badge.title) }}</h2>
         </header>
         {% include "badger/includes/badge_full.html" %}
     </section>

--- a/badgus/base/templates/badger/badges_by_user.html
+++ b/badgus/base/templates/badger/badges_by_user.html
@@ -10,7 +10,7 @@
 
 {% block content %}
 <section class="badge_list">
-    <h2>{{ _("Badges created by {user}") | f(user=user) }}</h2>
+    <h2>{{ _("Badges created by {user}") | fe(user=user) }}</h2>
     {% include "badger/includes/badges_list.html" %}
 </section>
 {% endblock %}

--- a/badgus/base/templates/badger/claim_deferred_award.html
+++ b/badgus/base/templates/badger/claim_deferred_award.html
@@ -8,7 +8,7 @@
 
     <section class="span4" id="detail">
         <header class="page-header">
-            <h2>{{ _("Badge: {badge_title}") | f(badge_title=badge.title) }}</h2>
+            <h2>{{ _("Badge: {badge_title}") | fe(badge_title=badge.title) }}</h2>
         </header>
         {% include "badger/includes/badge_full.html" %}
     </section>

--- a/badgus/base/templates/badger/claims_list.html
+++ b/badgus/base/templates/badger/claims_list.html
@@ -10,7 +10,7 @@
 
     <section class="span12">
         <header class="page-header">
-            <h2>{{ _("Claim codes for {badge}") | f(badge=badge) }}</h2>
+            <h2>{{ _("Claim codes for {badge}") | fe(badge=badge) }}</h2>
         </header>
         <ul class="deferred_awards">
             {% for deferred_award in deferred_awards %}

--- a/badgus/base/templates/badger/includes/pagination.html
+++ b/badgus/base/templates/badger/includes/pagination.html
@@ -1,6 +1,6 @@
 <nav class="pagination">
     {% if page_obj and page_obj.start_index() != page_obj.end_index() %}
-        <p class="showing">{{_('{start}&ndash;{end} of {total}') | f(start=page_obj.start_index(),end=page_obj.end_index(),total=paginator.count) | safe }}</p>
+        <p class="showing">{{_('{start}&ndash;{end} of {total}') | fe(start=page_obj.start_index(),end=page_obj.end_index(),total=paginator.count) | safe }}</p>
     {% endif %}
     {% if is_paginated %}
       <ul class="paging">

--- a/badgus/base/templates/badger/manage_claims.html
+++ b/badgus/base/templates/badger/manage_claims.html
@@ -10,7 +10,7 @@
 
     <section class="badge span4">
         <header class="page-header">
-            <h2 class="badge-title">{{ _("Badge: {badge_title}") | f(badge_title=badge.title) }}</h2>
+            <h2 class="badge-title">{{ _("Badge: {badge_title}") | fe(badge_title=badge.title) }}</h2>
         </header>
         {% include "badger/includes/badge_full.html" %}
     </section>
@@ -25,7 +25,7 @@
             <select name="amount">
                 <option value="1">1 reusable claim code</option>
                 {% for x in (6, 15, 30, 60, 90, 120, 150) %}
-                    <option value="{{ x }}">{{ _('{num} single-use claim codes') | f(num=x) }}</option>
+                    <option value="{{ x }}">{{ _('{num} single-use claim codes') | fe(num=x) }}</option>
                 {% endfor %}
             </select>
             <input type="submit" class="btn btn-large btn-primary submit" value="{{ _("Generate") }}">
@@ -43,7 +43,7 @@
                         <a class="btn" target="_blank" href="{{ url('badger.claims_list', badge.slug, item.claim_group) }}">
                             <strong class="modified">{{ item.modified }}</strong>
                             &#8212;
-                            <span class="count">{{ _('{count} single-use codes') | f(count=item.count) }}</span>
+                            <span class="count">{{ _('{count} single-use codes') | fe(count=item.count) }}</span>
                         </a>
                         &#8212;
                         <a class="btn btn-success" 

--- a/badgus/base/templates/badger/nomination_detail.html
+++ b/badgus/base/templates/badger/nomination_detail.html
@@ -7,7 +7,7 @@
 
     <section class="badge span4">
         <header class="page-header">
-            <h2>{{ _("Badge: {badge_title}") | f(badge_title=badge.title) }}</h2>
+            <h2>{{ _("Badge: {badge_title}") | fe(badge_title=badge.title) }}</h2>
         </header>
         {% include "badger/includes/badge_full.html" %}
     </section>

--- a/badgus/base/templates/valet_keys/list.html
+++ b/badgus/base/templates/valet_keys/list.html
@@ -25,7 +25,7 @@
             <td class="actions">
                 <a class="btn btn-info"
                    title="{{ _('View key usage history') }}"
-                   href="{{ url('valet_keys.history', pk=key.pk) }}">{{ _('History ({count})') | f(count=key.history.count()) }}</a>
+                   href="{{ url('valet_keys.history', pk=key.pk) }}">{{ _('History ({count})') | fe(count=key.history.count()) }}</a>
                 {% if not key.is_disabled %}
                     <a class="btn btn-danger"
                        title="{{ _('Disable key') }}"

--- a/badgus/profiles/templates/profiles/profile_view.html
+++ b/badgus/profiles/templates/profiles/profile_view.html
@@ -14,7 +14,7 @@
 
     <section class="span4" id="detail">
         <header class="page-header">
-            <h2>{{ _('Profile: {user}') | f(user=user) }}</h2>
+            <h2>{{ _('Profile: {user}') | fe(user=user) }}</h2>
         </header>
         <dl class="profile">
             {% if profile.display_name %}
@@ -84,7 +84,7 @@
     <section id="recent_awards" class="item_flow">
         <header class="page-header">
             <h3>
-                <span>{{ _('Recently awarded badges for {user}') | f(user=user) }}</span>
+                <span>{{ _('Recently awarded badges for {user}') | fe(user=user) }}</span>
                 <small>(
                     <a href="{{ url('badger.views.awards_by_user', profile.user.username) }}">More...</a>
                     <a href="{{ url('badger.feeds.awards_by_user', 'atom', profile.user.username) }}"><img src="{{ static('img/feed-icon-14x14.png') }}" /></a>
@@ -100,7 +100,7 @@
     <section id="recent_badges" class="item_flow">
         <header class="page-header">
             <h3>
-                <span>{{ _('Badges created by {user}') | f(user=user) }}</span>
+                <span>{{ _('Badges created by {user}') | fe(user=user) }}</span>
                 <small>(
                     <a href="{{ url('badger.views.badges_by_user', profile.user.username) }}">More...</a>
                     <a href="{{ url('badger.feeds.badges_by_user', 'atom', profile.user.username) }}"><img src="{{ static('img/feed-icon-14x14.png') }}" /></a>


### PR DESCRIPTION
Not entirely sure why `| f()` is throwing errors while `| fe()` is not. But, `| fe()` looks like what I'd rather be using anyway, [since it escapes the interpolated values while allowing the translated strings to be marked as safe](https://github.com/clouserw/tower#a-note-on-safe-ness).