### PR TITLE
Edit install directions: directory venv -> virtualenv

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,9 +23,9 @@ Development outside of Docker
 
 Here's how I get it running on my MacBook:
 
-    git clone 
+    git clone
     virtualenv --no-site-packages virtualenv
-    . ./venv/bin/activate
+    . ./virtualenv/bin/activate
     pip install -r requirements/dev.txt
     # Set up a mysql database
     # Edit badgus/settings/local.py


### PR DESCRIPTION
Removed an extra space at end of "git clone" and edited install directions: directory /venv/ -> /virtualenv/